### PR TITLE
Connect iOS map updates to shared locations

### DIFF
--- a/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/GoogleMapHostingController.kt
+++ b/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/GoogleMapHostingController.kt
@@ -1,0 +1,10 @@
+package charly.baquero.pocketmap
+
+import charly.baquero.pocketmap.domain.model.Location
+import kotlinx.cinterop.ObjCClassName
+import platform.UIKit.UIViewController
+
+@ObjCClassName("GoogleMapHostingController")
+external class GoogleMapHostingController : UIViewController {
+    fun render(locations: List<Location>)
+}

--- a/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/MainViewController.kt
@@ -1,13 +1,14 @@
 package charly.baquero.pocketmap
 
 import androidx.compose.ui.window.ComposeUIViewController
+import charly.baquero.pocketmap.domain.model.Location
 import platform.UIKit.UIViewController
 
 fun MainViewController(
-    mapUIViewController: () -> UIViewController
+    mapUIViewController: (List<Location>?) -> UIViewController
 ) = ComposeUIViewController {
     mapViewController = mapUIViewController
     App()
 }
 
-lateinit var mapViewController: () -> UIViewController
+lateinit var mapViewController: (List<Location>?) -> UIViewController

--- a/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/ui/map/MapComponent.ios.kt
+++ b/composeApp/src/iosMain/kotlin/charly/baquero/pocketmap/ui/map/MapComponent.ios.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitViewController
+import charly.baquero.pocketmap.GoogleMapHostingController
 import charly.baquero.pocketmap.domain.model.Location
 import charly.baquero.pocketmap.mapViewController
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -12,7 +13,11 @@ import kotlinx.cinterop.ExperimentalForeignApi
 @Composable
 actual fun MapComponent(locationList: List<Location>?) {
     UIKitViewController(
-        factory = mapViewController,
+        factory = { mapViewController(locationList) },
         modifier = Modifier.fillMaxSize(),
+        update = { controller ->
+            val hostingController = controller as? GoogleMapHostingController
+            hostingController?.render(locationList ?: emptyList())
+        },
     )
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -4,30 +4,73 @@ import ComposeApp
 import GoogleMaps
 
 struct GoogleMapView: UIViewRepresentable {
+    var locations: [Location]
+
     func makeUIView(context: Context) -> GMSMapView {
         let options = GMSMapViewOptions()
-        options.camera = GMSCameraPosition.camera(withLatitude: 41.4036, longitude: 2.1744, zoom: 10.0)
+        if let firstLocation = locations.first {
+            options.camera = GMSCameraPosition.camera(
+                withLatitude: firstLocation.latitude,
+                longitude: firstLocation.longitude,
+                zoom: 10.0
+            )
+        } else {
+            options.camera = GMSCameraPosition.camera(
+                withLatitude: 0.0,
+                longitude: 0.0,
+                zoom: 1.0
+            )
+        }
 
-        let mapView = GMSMapView(options: options)
-
-        // Creates a marker in the center of the map.
-        let marker = GMSMarker()
-        marker.position = CLLocationCoordinate2D(latitude: 41.4036, longitude: 2.1744)
-        marker.title = "Sagrada Familia"
-        marker.snippet = "Barcelona"
-        marker.map = mapView
-
-        return mapView
+        return GMSMapView(options: options)
     }
 
-    func updateUIView(_ uiView: GMSMapView, context: Context) {}
+    func updateUIView(_ uiView: GMSMapView, context: Context) {
+        uiView.clear()
+
+        for location in locations {
+            let marker = GMSMarker()
+            marker.position = CLLocationCoordinate2D(
+                latitude: location.latitude,
+                longitude: location.longitude
+            )
+            marker.title = location.title
+            marker.snippet = location.description_ ?? ""
+            marker.map = uiView
+        }
+
+        if let firstLocation = locations.first {
+            let camera = GMSCameraPosition.camera(
+                withLatitude: firstLocation.latitude,
+                longitude: firstLocation.longitude,
+                zoom: 10.0
+            )
+            uiView.animate(to: camera)
+        }
+    }
+}
+
+@MainActor
+final class GoogleMapHostingController: UIHostingController<GoogleMapView> {
+    init(locations: [Location]) {
+        super.init(rootView: GoogleMapView(locations: locations))
+    }
+
+    @MainActor @objc required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc func render(_ locations: [Location]) {
+        rootView = GoogleMapView(locations: locations)
+    }
 }
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         MainViewControllerKt.MainViewController(
-            mapUIViewController: { () -> UIViewController in
-                return UIHostingController(rootView: GoogleMapView())
+            mapUIViewController: { locationList in
+                let locations = locationList?.compactMap { $0 as? Location } ?? []
+                return GoogleMapHostingController(locations: locations)
             }
         )
     }


### PR DESCRIPTION
## Summary
- change the shared iOS entry point to accept a location-aware map view controller and expose it to Compose
- wire the iOS MapComponent factory/update to hand the latest location list to the UIKit controller
- replace the hard-coded Swift marker with a hosting controller that renders shared locations on Google Maps

## Testing
- `./gradlew composeApp:check` *(fails: missing Android SDK in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d12b60b00c832e9e6906cfc2608a93